### PR TITLE
Add support for other Body types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,12 @@
+AllCops:
+  TargetRubyVersion: 2.3
+  Include:
+    - Rakefile
+  Exclude:
+    - Gemfile
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
 Style/LineLength:
   Max: 180
 Style/ClassAndModuleChildren:
@@ -5,3 +14,4 @@ Style/ClassAndModuleChildren:
 Style/FileName:
   Exclude:
     - '**/mockserver-client.rb'
+    - 'mockserver-client.gemspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.3
+script:
+  - bundle exec rubocop
+  - ./build.sh

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
 # encoding: UTF-8
+
 require 'bundler/gem_tasks'
 require 'rubocop/rake_task'
 require 'rspec/core/rake_task'

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'thor'
 require 'colorize'
 require_relative './mockserver-client'
@@ -88,7 +90,7 @@ class MockServerCLI < Thor
   def retrieve
     execute_command do |client, _|
       result = options.data ? client.retrieve(read_file(options.data)) : client.retrieve
-      puts "RESULT:\n".bold + "#{result.to_json}".green
+      puts "RESULT:\n".bold + result.to_json.green
     end
   end
 

--- a/lib/mockserver-client.rb
+++ b/lib/mockserver-client.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './mockserver/version'
 require_relative './mockserver/mock_server_client'
 require_relative './mockserver/proxy_client'
@@ -7,6 +9,7 @@ require_relative './mockserver/proxy_client'
 require 'json/pure'
 
 # To fix serialization bugs. See: http://prettystatemachine.blogspot.com/2010/09/typeerrors-in-tojson-make-me-briefly.html
+# rubocop:disable Lint/UnifiedInteger
 class Fixnum
   def to_json(_)
     to_s

--- a/lib/mockserver/abstract_client.rb
+++ b/lib/mockserver/abstract_client.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'rest-client'
 require 'logging_factory'
 require_relative './model/times'
@@ -24,8 +26,8 @@ module MockServer
     attr_accessor :logger
 
     def initialize(host, port)
-      fail 'Cannot instantiate AbstractClient class. You must subclass it.' if self.class == AbstractClient
-      fail 'Host/port must not be nil' unless host && port
+      raise 'Cannot instantiate AbstractClient class. You must subclass it.' if self.class == AbstractClient
+      raise 'Host/port must not be nil' unless host && port
       protocol = ('https' if port == 443) || 'http'
       @base   = RestClient::Resource.new("#{protocol}://#{host}:#{port}", headers: { 'Content-Type' => 'application/json' })
       @logger = ::LoggingFactory::DEFAULT_FACTORY.log(self.class)
@@ -34,7 +36,7 @@ module MockServer
     # Clear all expectations with the given request
     # @param request [Request] the request to use to clear an expectation
     # @return [Object] the response from the clear action
-    def clear(request)
+    def clear(request) # rubocop:disable Metrics/AbcSize
       request = camelized_hash(HTTP_REQUEST => Request.new(symbolize_keys(request)))
 
       logger.debug("Clearing expectation with request: #{request}")
@@ -61,7 +63,7 @@ module MockServer
     # Retrieve the list of requests that have been processed by the server
     # @param request [Request] to filter requests
     # @return [Object] the list of responses processed by the server
-    def retrieve(request = nil)
+    def retrieve(request = nil) # rubocop:disable Metrics/AbcSize
       request = request ? camelized_hash(HTTP_REQUEST => Request.new(symbolize_keys(request))) : {}
 
       logger.debug('Retrieving request list from mockserver')
@@ -95,7 +97,7 @@ module MockServer
     # @param request [Request] to filter requests
     # @param times [Times] expected number of times
     # @return [Object] the list of responses processed by the server that match the request
-    def verify(request, times = exactly(1))
+    def verify(request, times = exactly(1)) # rubocop:disable Metrics/AbcSize
       logger.debug('Sending query for verify to mockserver')
       results   = retrieve(request)
 
@@ -105,7 +107,7 @@ module MockServer
       is_exact  = !times.unlimited
 
       fulfilled = is_exact ? (num_times == results.size) : (num_times <= results.size)
-      fail "Expected request to be present: [#{num_times}] (#{is_exact ? 'exactly' : 'at least'}). But found: [#{results.size}]" unless fulfilled
+      raise "Expected request to be present: [#{num_times}] (#{is_exact ? 'exactly' : 'at least'}). But found: [#{results.size}]" unless fulfilled
       results
     end
   end

--- a/lib/mockserver/mock_server_client.rb
+++ b/lib/mockserver/mock_server_client.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './model/expectation'
 require_relative './abstract_client'
 require_relative './utility_methods'
@@ -18,8 +20,8 @@ module MockServer
     # Registers an expectation with the mockserver
     # @param expectation [Expectation] the expectation to create the request from
     # @return [Object] the response from the register action
-    def register(expectation)
-      fail 'Expectation passed in is not valid type' unless expectation.is_a?(Expectation)
+    def register(expectation) # rubocop:disable Metrics/AbcSize
+      raise 'Expectation passed in is not valid type' unless expectation.is_a?(Expectation)
       request = create_expectation_request(expectation)
 
       logger.debug('Registering new expectation')
@@ -35,11 +37,10 @@ module MockServer
     # Create an expecation request to send to the expectation endpoint of
     # @param expectation [Expectation] the expectation  to create the request from
     # @return [Hash] a hash representing the request to use in registering an expectation with the mock server
-    # rubocop:disable Lint/LiteralInInterpolation
     def create_expectation_request(expectation)
       expectation_request = camelized_hash(expectation)
       logger.debug("Expectation JSON: #{expectation_request.to_json}")
-      fail "You can only set either of #{[HTTP_RESPONSE, HTTP_FORWARD]}. But not both" if expectation_request[HTTP_RESPONSE] && expectation_request[HTTP_FORWARD]
+      raise "You can only set either of #{[HTTP_RESPONSE, HTTP_FORWARD]}. But not both" if expectation_request[HTTP_RESPONSE] && expectation_request[HTTP_FORWARD]
       expectation_request
     end
   end

--- a/lib/mockserver/model/array_of.rb
+++ b/lib/mockserver/model/array_of.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
 # encoding: UTF-8
+
 #
 # The ArrayOf class stores instances of a given class only.
 # It enforces this by intercepting the methods :<<, :[]= and :insert on the Array class
@@ -15,9 +17,9 @@ module MockServer::Model
 
   # The ArrayOf class stores instances of a given class only.
   class ArrayOf < Array
-    alias_method :add_element, :<<
-    alias_method :set_element, :[]=
-    alias_method :insert_element, :insert
+    alias add_element <<
+    alias set_element []=
+    alias insert_element insert
 
     # Create an array from the elements passed in
     def initialize(items)
@@ -28,7 +30,7 @@ module MockServer::Model
 
     # The class/type that this array stores
     def child_class
-      fail 'Subclass should override method :child_class'
+      raise 'Subclass should override method :child_class'
     end
 
     # Add the item to the array
@@ -75,7 +77,7 @@ module MockServer::Model
       if item && item.class != child_class
         begin
           item = child_class.new(item)
-        rescue Exception => e # rubocop:disable Lint/RescueException
+        rescue StandardError => e
           raise "Failed to convert element: #{item} to required type #{child_class}. Error: #{e.message}"
         end
       end

--- a/lib/mockserver/model/body.rb
+++ b/lib/mockserver/model/body.rb
@@ -11,7 +11,16 @@ module MockServer::Model
   # An enum for body type
   class BodyType < SymbolizedEnum
     def allowed_values
-      [:STRING, :REGEX, :XPATH, :PARAMETERS, :BINARY]
+      [
+        :STRING,
+        :REGEX,
+        :XPATH,
+        :PARAMETERS,
+        :BINARY,
+        :JSON,
+        :JSON_SCHEMA,
+        :XML_SCHEMA
+      ]
     end
   end
 
@@ -39,6 +48,18 @@ module MockServer::Model
 
     def exact(value)
       Body.new(type: :STRING, value: value)
+    end
+
+    def json(value)
+      Body.new(type: :JSON, value: value)
+    end
+
+    def json_schema(value)
+      Body.new(type: :JSON_SCHEMA, value: value)
+    end
+
+    def xml_schema(value)
+      Body.new(type: :XML_SCHEMA, value: value)
     end
 
     def regex(value)

--- a/lib/mockserver/model/body.rb
+++ b/lib/mockserver/model/body.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './parameter'
 require_relative './enum'
@@ -11,16 +13,7 @@ module MockServer::Model
   # An enum for body type
   class BodyType < SymbolizedEnum
     def allowed_values
-      [
-        :STRING,
-        :REGEX,
-        :XPATH,
-        :PARAMETERS,
-        :BINARY,
-        :JSON,
-        :JSON_SCHEMA,
-        :XML_SCHEMA
-      ]
+      [:STRING, :REGEX, :XPATH, :PARAMETERS, :BINARY, :JSON, :JSON_SCHEMA, :XML_SCHEMA]
     end
   end
 

--- a/lib/mockserver/model/cookie.rb
+++ b/lib/mockserver/model/cookie.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './array_of'
 

--- a/lib/mockserver/model/delay.rb
+++ b/lib/mockserver/model/delay.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './enum'
 
 #

--- a/lib/mockserver/model/enum.rb
+++ b/lib/mockserver/model/enum.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # A class to model a Java-like Enum.
 # To create an Enum extend this class and override :allowed_values method with allowed enum values.
@@ -13,13 +15,13 @@ module MockServer::Model
     # @raise [Exception] if the supplied value is not valid for this enum
     def initialize(supplied_value)
       supplied_value = pre_process_value(supplied_value)
-      fail "Supplied value: #{supplied_value} is not valid. Allowed values are: #{allowed_values.inspect}" unless allowed_values.include?(supplied_value)
+      raise "Supplied value: #{supplied_value} is not valid. Allowed values are: #{allowed_values.inspect}" unless allowed_values.include?(supplied_value)
       @value = supplied_value
     end
 
     # @return [Array] a list of values allowed by this enum
     def allowed_values
-      fail 'Override :allowed_values in Enum class'
+      raise 'Override :allowed_values in Enum class'
     end
 
     # A pre-process hook for a value before it is stored

--- a/lib/mockserver/model/expectation.rb
+++ b/lib/mockserver/model/expectation.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './array_of'
 require_relative './request'
 require_relative './response'

--- a/lib/mockserver/model/forward.rb
+++ b/lib/mockserver/model/forward.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './enum'
 
@@ -36,6 +38,6 @@ module MockServer::Model
       obj
     end
 
-    alias_method :http_forward, :forward
+    alias :http_forward forward
   end
 end

--- a/lib/mockserver/model/header.rb
+++ b/lib/mockserver/model/header.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './array_of'
 

--- a/lib/mockserver/model/parameter.rb
+++ b/lib/mockserver/model/parameter.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './array_of'
 

--- a/lib/mockserver/model/request.rb
+++ b/lib/mockserver/model/request.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './parameter'
 require_relative './header'
@@ -23,8 +25,6 @@ module MockServer::Model
     include Hashie::Extensions::MethodAccess
     include Hashie::Extensions::IgnoreUndeclared
     include Hashie::Extensions::Coercion
-
-    ALLOWED_METHODS = [:GET, :POST, :PUT, :DELETE, :PATCH]
 
     property :method, required: true, default: :GET
     property :path, required: true, default: ''
@@ -77,7 +77,7 @@ module MockServer::Model
       body = payload['body']
 
       if body && body.is_a?(String)
-        payload.merge!('body' => { 'type' => :STRING, 'value' => body })
+        payload['body'] = { 'type' => :STRING, 'value' => body }
       end
 
       request = Request.new(symbolize_keys(payload))
@@ -85,6 +85,6 @@ module MockServer::Model
       request
     end
 
-    alias_method :http_request, :request
+    alias http_request request
   end
 end

--- a/lib/mockserver/model/response.rb
+++ b/lib/mockserver/model/response.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './body'
 require_relative './delay'
 require_relative './header'
@@ -40,6 +42,6 @@ module MockServer::Model
       Base64.decode64(string)
     end
 
-    alias_method :http_response, :response
+    alias http_response response
   end
 end

--- a/lib/mockserver/model/times.rb
+++ b/lib/mockserver/model/times.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'hashie'
 require_relative './enum'
 

--- a/lib/mockserver/proxy_client.rb
+++ b/lib/mockserver/proxy_client.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative './abstract_client'
 
 #

--- a/lib/mockserver/utility_methods.rb
+++ b/lib/mockserver/utility_methods.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'active_support/inflector'
 require 'json'
 
@@ -12,8 +14,7 @@ module MockServer::UtilityMethods
   # - camelize the keys of the hash
   # @param obj [Object] an object which will be used to create the hash. Must support :to_hash method
   # @return [Hash] the transformed hash
-  # rubocop:disable Style/MethodLength
-  # rubocop:disable Style/CyclomaticComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
   def camelized_hash(obj)
     obj = obj && obj.respond_to?(:to_hash) ? obj.to_hash : obj
 

--- a/lib/mockserver/version.rb
+++ b/lib/mockserver/version.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 # Version for this gem
 module MockServer
   VERSION = '1.0.8.pre'

--- a/mockserver-client.gemspec
+++ b/mockserver-client.gemspec
@@ -1,9 +1,11 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mockserver/version'
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name        = 'mockserver-client'
   spec.version     = MockServer::VERSION
   spec.authors     = ['Nayyara Samuel', 'James D Bloom']
@@ -16,22 +18,22 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '~> 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1'
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.8'
-  spec.add_development_dependency 'webmock', '~> 1.18'
+  spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'rubocop', '~> 0.23'
 
   spec.add_dependency 'hashie', '~> 3.0'
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'json_pure', '~> 1.8'
   spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'rest-client', '~> 1.7'
+  spec.add_dependency 'rest-client'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'colorize', '~> 0.7'

--- a/spec/integration/mock_client_integration_spec.rb
+++ b/spec/integration/mock_client_integration_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'rspec'
 require 'net/http'
 require 'webmock/rspec'
@@ -16,6 +18,7 @@ RSpec.configure do |config|
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 shared_context 'setup expectation' do
   let(:client) { MockServer::MockServerClient.new('localhost', 8098) }
 
@@ -70,12 +73,12 @@ shared_context 'setup expectation' do
     url_params = %(?param=#{param}) if param
 
     # when
-    uri           = URI('http://localhost:8098')
-    http          = Net::HTTP.new(uri.host, uri.port)
-    req           = Net::HTTP::Post.new(%(#{request_path}#{url_params}))
+    uri = URI('http://localhost:8098')
+    http = Net::HTTP.new(uri.host, uri.port)
+    req = Net::HTTP::Post.new(%(#{request_path}#{url_params}))
     setup_request req
-    req.body      = request_body
-    @res           = http.request(req)
+    req.body = request_body
+    @res = http.request(req)
 
     WebMock.disable_net_connect!
   end
@@ -93,7 +96,6 @@ shared_examples 'a successful mock response' do
     expect(@res.body).to eq(response_body)
   end
 end
-
 
 describe MockServer::MockServerClient do
   context 'when a complex expectation is set up' do
@@ -132,16 +134,20 @@ describe MockServer::MockServerClient do
 
   context 'when the mock body type is json schema' do
     include_context 'setup expectation' do
-      let(:expectation_body) {
+      let(:expectation_body) do
         json_schema({
           type: 'object',
           properties: {
-              id: { type: 'integer' },
-              name: { type: 'string' }
+            id: {
+              type: 'integer'
+            },
+            name: {
+              type: 'string'
+            }
           },
-          required: ['id', 'name']
+          required: %w[id name]
         }.to_json)
-      }
+      end
       let(:request_body) { { id: 123, name: 'bob' }.to_json }
     end
 
@@ -151,10 +157,12 @@ describe MockServer::MockServerClient do
 
   context 'when the mock body type is xml schema' do
     include_context 'setup expectation' do
-      let(:expectation_body) { xml_schema('
-        <xs:element name="id" type="xs:integer"/>
-        <xs:element name="name" type="xs:string"/>
-      ') }
+      let(:expectation_body) do
+        xml_schema('
+          <xs:element name="id" type="xs:integer"/>
+          <xs:element name="name" type="xs:string"/>
+        ')
+      end
       let(:request_body) { { id: 123, name: 'bob' }.to_json }
     end
 

--- a/spec/mockserver/builder_spec.rb
+++ b/spec/mockserver/builder_spec.rb
@@ -1,32 +1,34 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe MockServer::Model::DSL do
-
   it 'generates http requests correctly' do
-    mock_request                  = http_request(:POST, '/login')
+    mock_request = http_request(:POST, '/login')
     mock_request.query_string_parameters = [parameter('returnUrl', '/account')]
-    mock_request.cookies          = [cookie('sessionId', '2By8LOhBmaW5nZXJwcmludCIlMDAzMW')]
-    mock_request.body             = exact("{username:'foo', password:'bar'}")
+    mock_request.cookies = [cookie('sessionId', '2By8LOhBmaW5nZXJwcmludCIlMDAzMW')]
+    mock_request.body = exact("{username:'foo', password:'bar'}")
 
     expect(to_camelized_hash(HTTP_REQUEST => mock_request)).to eq(FIXTURES.read('post_login_request.json'))
 
     # Block style
     mock_request = request(:POST, '/login') do |request|
       request.query_string_parameters = [parameter('returnUrl', '/account')]
-      request.cookies          = [cookie('sessionId', '2By8LOhBmaW5nZXJwcmludCIlMDAzMW')]
-      request.body             = exact("{username:'foo', password:'bar'}")
+      request.cookies = [cookie('sessionId', '2By8LOhBmaW5nZXJwcmludCIlMDAzMW')]
+      request.body = exact("{username:'foo', password:'bar'}")
     end
 
     expect(to_camelized_hash(HTTP_REQUEST => mock_request)).to eq(FIXTURES.read('post_login_request.json'))
   end
 
   it 'generates http responses correctly' do
-    mock_response             = http_response
+    mock_response = http_response
     mock_response.status_code = 401
-    mock_response.headers     = [header('Content-Type', 'application/json; charset=utf-8')]
+    mock_response.headers = [header('Content-Type', 'application/json; charset=utf-8')]
     mock_response.headers << header('Cache-Control', 'public, max-age=86400')
-    mock_response.body  = body('incorrect username and password combination')
+    mock_response.body = body('incorrect username and password combination')
     mock_response.delay = delay_by(:SECONDS, 1)
 
     expect(to_camelized_hash(HTTP_RESPONSE => mock_response)).to eq(FIXTURES.read('incorrect_login_response.json'))
@@ -34,9 +36,9 @@ describe MockServer::Model::DSL do
     # Block style
     mock_response = response do |response|
       response.status_code = 401
-      response.headers     = [header('Content-Type', 'application/json; charset=utf-8')]
+      response.headers = [header('Content-Type', 'application/json; charset=utf-8')]
       response.headers << header('Cache-Control', 'public, max-age=86400')
-      response.body  = body('incorrect username and password combination')
+      response.body = body('incorrect username and password combination')
       response.delay = delay_by(:SECONDS, 1)
     end
 
@@ -44,7 +46,7 @@ describe MockServer::Model::DSL do
   end
 
   it 'generates http forwards correctly' do
-    mock_forward      = http_forward
+    mock_forward = http_forward
     mock_forward.host = 'www.mock-server.com'
     mock_forward.port = 80
 
@@ -70,7 +72,7 @@ describe MockServer::Model::DSL do
   end
 
   it 'generates expectation correctly from file' do
-    payload          = FIXTURES.read('register_expectation.json')
+    payload = FIXTURES.read('register_expectation.json')
     mock_expectation = expectation_from_json(payload)
 
     expect(to_camelized_hash(mock_expectation.to_hash)).to eq(payload)
@@ -87,28 +89,27 @@ describe MockServer::Model::DSL do
     expect(to_camelized_hash(at_least(2))).to eq('unlimited' => 'true', 'remainingTimes' => 2)
   end
 
-
   describe 'transforming request body' do
     let(:expectation) { MockServer::Model::Expectation.new }
     let(:request) { MockServer::Model::Request.new }
 
-    [{type: :XPATH, value: '/mock/instance'},
-     {type: :REGEX, value: '\d+.\d+'},
-     {type: :STRING, value: 'Mockserver is great'}].each do |request_hash|
+    [{ type: :XPATH, value: '/mock/instance' },
+     { type: :REGEX, value: '\d+.\d+' },
+     { type: :STRING, value: 'Mockserver is great' }].each do |request_hash|
 
       it "generates a request body of type #{request_hash[:type]}" do
         request.body = MockServer::Model::Body.new(request_hash)
         expectation.request = request
 
-        expect(to_camelized_hash(expectation)).to eq({
-          "httpRequest" => {
-          "method" => "GET",
-            "body" => {
-              "type"  => request_hash[:type].to_s,
-              "value" => request_hash[:value].to_s
+        expect(to_camelized_hash(expectation)).to eq(
+          'httpRequest' => {
+            'method' => 'GET',
+            'body' => {
+              'type'  => request_hash[:type].to_s,
+              'value' => request_hash[:value].to_s
             }
           }
-        })
+        )
       end
     end
 
@@ -121,15 +122,15 @@ describe MockServer::Model::DSL do
         request.body = body
         expectation.request = request
 
-        expect(to_camelized_hash(expectation)).to eq({
-          "httpRequest" => {
-            "method" => "GET",
-            "body" => {
-              "type" => "STRING",
-              "value" => "Mockserver is great\n"
+        expect(to_camelized_hash(expectation)).to eq(
+          'httpRequest' => {
+            'method' => 'GET',
+            'body' => {
+              'type' => 'STRING',
+              'value' => "Mockserver is great\n"
             }
           }
-        })
+        )
       end
     end
   end

--- a/spec/mockserver/mock_client_spec.rb
+++ b/spec/mockserver/mock_client_spec.rb
@@ -1,8 +1,10 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe MockServer::MockServerClient do
-
   let(:client) { MockServer::MockServerClient.new('localhost', 8080) }
   let(:register_expectation_json) { FIXTURES.read('register_expectation.json').to_json }
   let(:search_request_json) { FIXTURES.read('search_request.json').to_json }
@@ -12,10 +14,10 @@ describe MockServer::MockServerClient do
     client.logger = LoggingFactory::DEFAULT_FACTORY.log('test', output: 'tmp.log', truncate: true)
 
     # Stub requests
-    stub_request(:put, /.+\/expectation/).with(body: register_expectation_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 201)
-    stub_request(:put, /.+\/clear/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
-    stub_request(:put, /.+\/reset/).with(headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
-    stub_request(:put, /.+\/retrieve/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(
+    stub_request(:put, %r{.+/expectation}).with(body: register_expectation_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 201)
+    stub_request(:put, %r{.+/clear}).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, %r{.+/reset}).with(headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, %r{.+/retrieve}).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(
       body: '[]',
       status: 200
     )
@@ -25,7 +27,7 @@ describe MockServer::MockServerClient do
     mock_expectation = expectation do |expectation|
       expectation.request do |request|
         request.method = 'POST'
-        request.path   = '/login'
+        request.path = '/login'
         request.query_string_parameters << parameter('returnUrl', '/account')
         request.cookies << cookie('sessionId', '2By8LOhBmaW5nZXJwcmludCIlMDAzMW')
         request.body = exact({ username: 'foo', password: 'bar' }.to_json)
@@ -35,7 +37,7 @@ describe MockServer::MockServerClient do
         response.status_code = 401
         response.headers << header('Content-Type', 'application/json; charset=utf-8')
         response.headers << header('Cache-Control', 'public, max-age=86400')
-        response.body  = body({ message: 'incorrect username and password combination' }.to_json)
+        response.body = body({ message: 'incorrect username and password combination' }.to_json)
         response.delay = delay_by(:SECONDS, 1)
       end
 
@@ -50,7 +52,7 @@ describe MockServer::MockServerClient do
     mock_expectation = expectation do |expectation|
       expectation.request do |request|
         request.method = 'POST'
-        request.path   = '/login'
+        request.path = '/login'
       end
 
       expectation.response do |response|
@@ -76,5 +78,4 @@ describe MockServer::MockServerClient do
   it 'retrieves requests correctly' do
     expect(client.retrieve(request(:POST, '/login')).code).to eq(200)
   end
-
 end

--- a/spec/mockserver/model/dsl_spec.rb
+++ b/spec/mockserver/model/dsl_spec.rb
@@ -1,5 +1,9 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'MockServer::Model::DSL' do
   let(:header) { MockServer::Model::Header }
   let(:headers) do
@@ -16,12 +20,17 @@ RSpec.describe 'MockServer::Model::DSL' do
     let(:body_content) { 'Hello this is a message' }
     let(:request_json) do
       {
-        "method"=>"POST", "path"=>"/message",
-        "headers"=>[{ "name"=>"User-Agent", "values"=>["curl/7.22.0 (x86_64-pc-linux-gnu)"] },
-        {"name"=>"Host", "values"=>["localhost:2000"]}, {"name"=>"Accept", "values"=>["*/*"]},
-        {"name"=>"Content-Length", "values"=>["26"]},
-        {"name"=>"Content-Type", "values"=>["application/x-www-form-urlencoded"]}],
-        "keepAlive"=>true, "secure"=>false
+        'method' => 'POST',
+        'path' => '/message',
+        'headers' => [
+          { 'name' => 'User-Agent', 'values' => ['curl/7.22.0 (x86_64-pc-linux-gnu)'] },
+          { 'name' => 'Host', 'values' => ['localhost:2000'] },
+          { 'name' => 'Accept', 'values' => ['*/*'] },
+          { 'name' => 'Content-Length', 'values' => ['26'] },
+          { 'name' => 'Content-Type', 'values' => ['application/x-www-form-urlencoded'] }
+        ],
+        'keepAlive' => true,
+        'secure' => false
       }
     end
 

--- a/spec/mockserver/proxy_client_spec.rb
+++ b/spec/mockserver/proxy_client_spec.rb
@@ -1,8 +1,9 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe MockServer::ProxyClient do
-
   let(:client) { MockServer::ProxyClient.new('localhost', 8080) }
   let(:retrieved_request) { FIXTURES.read('retrieved_request.json') }
   let(:retrieved_request_json) { retrieved_request.to_json }
@@ -13,12 +14,12 @@ describe MockServer::ProxyClient do
     client.logger = LoggingFactory::DEFAULT_FACTORY.log('test', output: 'tmp.log', truncate: true)
 
     # Stub requests
-    stub_request(:put, /.+\/retrieve/).with(body: search_request_json).to_return(
-      body:   "[#{retrieved_request_json}, #{retrieved_request_json}]",
+    stub_request(:put, %r{.+/retrieve}).with(body: search_request_json).to_return(
+      body: "[#{retrieved_request_json}, #{retrieved_request_json}]",
       status: 200
     )
-    stub_request(:put, /.+\/dumpToLog$/).to_return(status: 202).once
-    stub_request(:put, /.+\/dumpToLog\?type=java$/).to_return(status: 202).once
+    stub_request(:put, %r{.+/dumpToLog$}).to_return(status: 202).once
+    stub_request(:put, %r{.+/dumpToLog\?type=java$}).to_return(status: 202).once
   end
 
   it 'verifies requests correctly' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'simplecov'
 
 SimpleCov.start do
@@ -20,7 +22,7 @@ module HelperMethods
 
     # Options should have a list of parts which will be appended together to give the base path
     def initialize(*options)
-      @base_path = File.join(options.map { |f| f.to_s })
+      @base_path = File.join(options.map(&:to_s))
     end
 
     # Access specific file in the base path


### PR DESCRIPTION
The current ruby client only supports a request body of type: `STRING`, `REGEX`, `XPATH`, `PARAMETERS` and `BINARY`. 

The server supports a couple more. My team is using the client and we are trying to use `JSON` to set our expectations because using `exact` forces us to pass the arguments in the exact same order as the expectation. 

This PR adds support on the client for these extra body types that are supported on the server: `JSON`, `JSON_SCHEMA` and `XML_SCHEMA`. 

This PR also refactors the integration test so the context and examples can be reused and adds tests to ensure the interaction with the new body types works. The tests all pass.

I also noticed that the coverage is not working in this project. It detects 0 lines, so I couldn't explore if the test coverage went up or down. However, every line of code added was tested.